### PR TITLE
fix: remove framework quality

### DIFF
--- a/src/database/SsiAuthoritySchemaRegistry.Migrations/Seeder/Data/credential_authorities.json
+++ b/src/database/SsiAuthoritySchemaRegistry.Migrations/Seeder/Data/credential_authorities.json
@@ -16,10 +16,6 @@
     "bpn": "BPNL00000003CRHK"
   },
   {
-    "credential_id": "255e01fc-65f6-43cd-8dfa-95e95fa95f64",
-    "bpn": "BPNL00000003CRHK"
-  },
-  {
     "credential_id": "255e01fc-65f6-43cd-8dfa-95e95fa95f65",
     "bpn": "BPNL00000003CRHK"
   },

--- a/src/database/SsiAuthoritySchemaRegistry.Migrations/Seeder/Data/credentials.json
+++ b/src/database/SsiAuthoritySchemaRegistry.Migrations/Seeder/Data/credentials.json
@@ -20,11 +20,6 @@
     "name": "QualityCredential"
   },
   {
-    "id": "255e01fc-65f6-43cd-8dfa-95e95fa95f64",
-    "type_id": 3,
-    "name": "Framework Quality"
-  },
-  {
     "id": "255e01fc-65f6-43cd-8dfa-95e95fa95f65",
     "type_id": 3,
     "name": "CircularEconomyCredential"

--- a/tests/database/SsiAuthoritySchemaRegistry.DbAccess.Tests/CredentialRepositoryTests.cs
+++ b/tests/database/SsiAuthoritySchemaRegistry.DbAccess.Tests/CredentialRepositoryTests.cs
@@ -55,12 +55,11 @@ public class CredentialRepositoryTests
         var result = await sut.GetCredentials(null, null).ToListAsync();
 
         // Assert
-        result.Should().HaveCount(12).And.Satisfy(
+        result.Should().HaveCount(11).And.Satisfy(
             x => x.CredentialName == "BusinessPartnerNumber" && x.Credential == "BusinessPartnerCredential",
             x => x.CredentialName == "Membership" && x.Credential == "MembershipCredential",
             x => x.CredentialName == "Framework" && x.Credential == "TraceabilityCredential",
             x => x.CredentialName == "Framework" && x.Credential == "QualityCredential",
-            x => x.CredentialName == "Framework" && x.Credential == "Framework Quality",
             x => x.CredentialName == "Framework" && x.Credential == "CircularEconomyCredential",
             x => x.CredentialName == "Framework" && x.Credential == "PcfCredential",
             x => x.CredentialName == "Framework" && x.Credential == "DemandCapacityCredential",
@@ -94,10 +93,9 @@ public class CredentialRepositoryTests
         var result = await sut.GetCredentials(null, CredentialTypeId.Framework).ToListAsync();
 
         // Assert
-        result.Should().HaveCount(9).And.Satisfy(
+        result.Should().HaveCount(8).And.Satisfy(
             x => x.CredentialName == "Framework" && x.Credential == "TraceabilityCredential",
             x => x.CredentialName == "Framework" && x.Credential == "QualityCredential",
-            x => x.CredentialName == "Framework" && x.Credential == "Framework Quality",
             x => x.CredentialName == "Framework" && x.Credential == "CircularEconomyCredential",
             x => x.CredentialName == "Framework" && x.Credential == "PcfCredential",
             x => x.CredentialName == "Framework" && x.Credential == "DemandCapacityCredential",

--- a/tests/registry/SsiAuthoritySchemaRegistry.Service.Tests/Controllers/RegistryControllerTests.cs
+++ b/tests/registry/SsiAuthoritySchemaRegistry.Service.Tests/Controllers/RegistryControllerTests.cs
@@ -52,12 +52,11 @@ public class RegistryControllerTests(IntegrationTestFactory factory) : IClassFix
         var data = await _client.GetFromJsonAsync<IEnumerable<CredentialData>>($"{BaseUrl}/credentials", JsonOptions);
 
         // Assert
-        data.Should().NotBeNull().And.HaveCount(12).And.Satisfy(
+        data.Should().NotBeNull().And.HaveCount(11).And.Satisfy(
             x => x.CredentialName == "BusinessPartnerNumber" && x.Credential == "BusinessPartnerCredential",
             x => x.CredentialName == "Membership" && x.Credential == "MembershipCredential",
             x => x.CredentialName == "Framework" && x.Credential == "TraceabilityCredential",
             x => x.CredentialName == "Framework" && x.Credential == "QualityCredential",
-            x => x.CredentialName == "Framework" && x.Credential == "Framework Quality",
             x => x.CredentialName == "Framework" && x.Credential == "CircularEconomyCredential",
             x => x.CredentialName == "Framework" && x.Credential == "PcfCredential",
             x => x.CredentialName == "Framework" && x.Credential == "DemandCapacityCredential",
@@ -86,10 +85,9 @@ public class RegistryControllerTests(IntegrationTestFactory factory) : IClassFix
         var data = await _client.GetFromJsonAsync<IEnumerable<CredentialData>>($"{BaseUrl}/credentials?credentialTypeId={CredentialTypeId.Framework}", JsonOptions);
 
         // Assert
-        data.Should().HaveCount(9).And.Satisfy(
+        data.Should().HaveCount(8).And.Satisfy(
             x => x.CredentialName == "Framework" && x.Credential == "TraceabilityCredential",
             x => x.CredentialName == "Framework" && x.Credential == "QualityCredential",
-            x => x.CredentialName == "Framework" && x.Credential == "Framework Quality",
             x => x.CredentialName == "Framework" && x.Credential == "CircularEconomyCredential",
             x => x.CredentialName == "Framework" && x.Credential == "PcfCredential",
             x => x.CredentialName == "Framework" && x.Credential == "DemandCapacityCredential",


### PR DESCRIPTION
## Description

Remove framework quality credential

## Why

The credential was duplicated

## Issue

Refs: #33

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-authority-schema-registry/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)