### PR TITLE
chore(dependencies): bump efcore to 8.0.7

### DIFF
--- a/src/database/SsiAuthoritySchemaRegistry.DbAccess/SsiAuthoritySchemaRegistry.DbAccess.csproj
+++ b/src/database/SsiAuthoritySchemaRegistry.DbAccess/SsiAuthoritySchemaRegistry.DbAccess.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.7" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />
     <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DependencyInjection" Version="2.3.0" />
     <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling" Version="2.3.0" />

--- a/src/database/SsiAuthoritySchemaRegistry.Entities/SsiAuthoritySchemaRegistry.Entities.csproj
+++ b/src/database/SsiAuthoritySchemaRegistry.Entities/SsiAuthoritySchemaRegistry.Entities.csproj
@@ -29,7 +29,7 @@
 
     <ItemGroup>
       <PackageReference Include="EFCore.NamingConventions" Version="8.0.3" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.6" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.7" />
     </ItemGroup>
 
 </Project>

--- a/src/database/SsiAuthoritySchemaRegistry.Migrations/SsiAuthoritySchemaRegistry.Migrations.csproj
+++ b/src/database/SsiAuthoritySchemaRegistry.Migrations/SsiAuthoritySchemaRegistry.Migrations.csproj
@@ -34,7 +34,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.6">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.7">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>


### PR DESCRIPTION
## Description

increase efcore version to latest 8.0.7

## Why

efcore 8.0.5 has transitive dependency System.Text.Json 8.0.0 which has a security-vulerability that is clasified as high. Upgrade to efcore 8.0.7 implicitly upgrades this dependency to System.Text.Json 8.0.4 which resolves the vulnerability.

## Issue

https://github.com/eclipse-tractusx/portal/issues/369

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-authority-schema-registry/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally
- [X] I have checked that new and existing tests pass locally with my changes
