### PR TITLE
docs: remove authentication from documentation

### DIFF
--- a/docs/architecture/Solution strategy.md
+++ b/docs/architecture/Solution strategy.md
@@ -1,8 +1,7 @@
 # Solution Strategy
 
 - The technology portfolio and development stack are kept simple, based on commodity and oss components and products.
-- APIs are always REST-based with token authentication.
-- OIDC is used for authentication and authorization.
+- APIs are always REST-based.
 - IaC is fully realized via helm charts.
 
 ## NOTICE


### PR DESCRIPTION
## Description

remove authentication  from documentation

## Why

Since the application does not use authentication it was removed from the documentation

## Issue

Refs: #84

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-authority-schema-registry/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)