### PR TITLE
chore(dependencies): bump System.Text.Json to 8.0.4

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -24,7 +24,7 @@ nuget/nuget/-/Serilog.Enrichers.Thread/3.1.0, Apache-2.0, approved, clearlydefin
 nuget/nuget/-/Serilog.Extensions.Hosting/8.0.0, Apache-2.0, approved, #13962
 nuget/nuget/-/Serilog.Extensions.Logging/8.0.0, Apache-2.0, approved, #13985
 nuget/nuget/-/Serilog.Formatting.Compact/2.0.0, Apache-2.0, approved, #13981
-nuget/nuget/-/Serilog.Settings.Configuration/8.0.0, Apache-2.0, approved, #13988
+nuget/nuget/-/Serilog.Settings.Configuration/8.0.2, Apache-2.0, approved, #13988
 nuget/nuget/-/Serilog.Sinks.Console/5.0.1, Apache-2.0, approved, #13980
 nuget/nuget/-/Serilog.Sinks.Debug/2.0.0, Apache-2.0, approved, clearlydefined
 nuget/nuget/-/Serilog.Sinks.File/5.0.0, Apache-2.0, approved, #11116

--- a/src/database/SsiAuthoritySchemaRegistry.DbAccess/SsiAuthoritySchemaRegistry.DbAccess.csproj
+++ b/src/database/SsiAuthoritySchemaRegistry.DbAccess/SsiAuthoritySchemaRegistry.DbAccess.csproj
@@ -34,8 +34,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.7" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DependencyInjection" Version="2.3.0" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling" Version="2.3.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DependencyInjection" Version="2.4.2" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling" Version="2.4.2" />
   </ItemGroup>
 
 </Project>

--- a/src/database/SsiAuthoritySchemaRegistry.Entities/SsiAuthoritySchemaRegistry.Entities.csproj
+++ b/src/database/SsiAuthoritySchemaRegistry.Entities/SsiAuthoritySchemaRegistry.Entities.csproj
@@ -29,7 +29,7 @@
 
     <ItemGroup>
       <PackageReference Include="EFCore.NamingConventions" Version="8.0.3" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.7" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.7" />
     </ItemGroup>
 
 </Project>

--- a/src/database/SsiAuthoritySchemaRegistry.Migrations/SsiAuthoritySchemaRegistry.Migrations.csproj
+++ b/src/database/SsiAuthoritySchemaRegistry.Migrations/SsiAuthoritySchemaRegistry.Migrations.csproj
@@ -47,9 +47,9 @@
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />
-        <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Linq" Version="2.3.0" />
-        <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Logging" Version="2.3.0" />
-        <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Seeding" Version="2.3.0" />
+        <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Linq" Version="2.4.2" />
+        <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Logging" Version="2.4.2" />
+        <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Seeding" Version="2.4.2" />
         <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
     </ItemGroup>
 

--- a/src/registry/SsiAuthoritySchemaRegistry.Service/SsiAuthoritySchemaRegistry.Service.csproj
+++ b/src/registry/SsiAuthoritySchemaRegistry.Service/SsiAuthoritySchemaRegistry.Service.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="JsonSchema.Net" Version="7.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.6" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.6" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Web" Version="2.3.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Web" Version="2.4.2" />
     <PackageReference Include="System.Json" Version="4.7.1" />
     <PackageReference Include="System.Linq" Version="4.3.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />

--- a/tests/database/SsiAuthoritySchemaRegistry.DbAccess.Tests/SsiAuthoritySchemaRegistry.DbAccess.Tests.csproj
+++ b/tests/database/SsiAuthoritySchemaRegistry.DbAccess.Tests/SsiAuthoritySchemaRegistry.DbAccess.Tests.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="FakeItEasy" Version="8.2.0" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DateTimeProvider" Version="2.3.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DateTimeProvider" Version="2.4.2" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="3.8.0" />
     <PackageReference Include="xunit" Version="2.7.0" />


### PR DESCRIPTION
## Description

dependency to Microsoft.EntityFrameworkCore was changed to Microsoft.EntityFrameworkCore.Design 8.0.7

## Why

System.Text.Json 8.0.0 has a vulnerability that must be fixed. It is references as an implicit dependency. Referencing Microsoft.EntityFrameworkCore.Design 8.0.7 instead of Microsoft.EntityFrameworkCore implicitly upgrades System.Json.Text to 8.0.4 which solves the security-issue.

## Issue

https://github.com/eclipse-tractusx/portal/issues/369

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-authority-schema-registry/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally
- [X] I have checked that new and existing tests pass locally with my changes
