### PR TITLE
feat(framework): adjust seeding data

### DIFF
--- a/src/database/SsiAuthoritySchemaRegistry.Migrations/Seeder/BatchDeleteSeeder.cs
+++ b/src/database/SsiAuthoritySchemaRegistry.Migrations/Seeder/BatchDeleteSeeder.cs
@@ -1,0 +1,72 @@
+/********************************************************************************
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.Seeding;
+using Org.Eclipse.TractusX.SsiAuthoritySchemaRegistry.Entities;
+using Org.Eclipse.TractusX.SsiAuthoritySchemaRegistry.Entities.Entities;
+
+namespace Org.Eclipse.TractusX.SsiAuthoritySchemaRegistry.Migrations.Seeder;
+
+/// <summary>
+/// Seeder to seed the all configured entities
+/// </summary>
+public class BatchDeleteSeeder(RegistryContext context, ILogger<BatchDeleteSeeder> logger, IOptions<SeederSettings> options)
+    : ICustomSeeder
+{
+    private readonly SeederSettings _settings = options.Value;
+
+    /// <inheritdoc />
+    public int Order => 2;
+
+    /// <inheritdoc />
+    public async Task ExecuteAsync(CancellationToken cancellationToken)
+    {
+        if (!_settings.DataPaths.Any())
+        {
+            logger.LogInformation("There a no data paths configured, therefore the {SeederName} will be skipped", nameof(BatchInsertSeeder));
+            return;
+        }
+
+        await SeedTable<Authority>("authorities", x => x.Bpn, cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
+        await SeedTable<Credential>("credentials", x => x.Id, cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
+        await SeedTable<CredentialAuthority>("credential_authorities", x => new { x.CredentialId, x.Bpn }, cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
+
+        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
+    }
+
+    private async Task SeedTable<T>(string fileName, Func<T, object> keySelector, CancellationToken cancellationToken)
+        where T : class
+    {
+        logger.LogDebug("Start seeding {Filename}", fileName);
+        var additionalEnvironments = _settings.TestDataEnvironments ?? Enumerable.Empty<string>();
+        var data = await SeederHelper
+            .GetSeedData<T>(logger, fileName, _settings.DataPaths, cancellationToken, additionalEnvironments.ToArray())
+            .ConfigureAwait(false);
+        logger.LogDebug("Found {ElementCount} data", data.Count);
+
+        // Identify entities in the database that are not present in the JSON data
+        var existingEntities = await context.Set<T>().ToListAsync(cancellationToken).ConfigureAwait(false);
+        var entitiesToRemove = existingEntities
+            .Where(dbEntity => data.All(jsonEntity => !keySelector(dbEntity).Equals(keySelector(jsonEntity)))).ToList();
+        context.Set<T>().RemoveRange(entitiesToRemove);
+    }
+}

--- a/src/database/SsiAuthoritySchemaRegistry.Migrations/Seeder/Data/credential_authorities.json
+++ b/src/database/SsiAuthoritySchemaRegistry.Migrations/Seeder/Data/credential_authorities.json
@@ -8,43 +8,15 @@
     "bpn": "BPNL00000003CRHK"
   },
   {
-    "credential_id": "255e01fc-65f6-43cd-8dfa-95e95fa95f62",
-    "bpn": "BPNL00000003CRHK"
-  },
-  {
-    "credential_id": "255e01fc-65f6-43cd-8dfa-95e95fa95f63",
-    "bpn": "BPNL00000003CRHK"
-  },
-  {
-    "credential_id": "255e01fc-65f6-43cd-8dfa-95e95fa95f65",
-    "bpn": "BPNL00000003CRHK"
-  },
-  {
-    "credential_id": "255e01fc-65f6-43cd-8dfa-95e95fa95f66",
-    "bpn": "BPNL00000003CRHK"
-  },
-  {
-    "credential_id": "255e01fc-65f6-43cd-8dfa-95e95fa95f67",
-    "bpn": "BPNL00000003CRHK"
-  },
-  {
-    "credential_id": "255e01fc-65f6-43cd-8dfa-95e95fa95f68",
-    "bpn": "BPNL00000003CRHK"
-  },
-  {
-    "credential_id": "255e01fc-65f6-43cd-8dfa-95e95fa95f69",
-    "bpn": "BPNL00000003CRHK"
-  },
-  {
-    "credential_id": "255e01fc-65f6-43cd-8dfa-95e95fa95f6a",
-    "bpn": "BPNL00000003CRHK"
-  },
-  {
     "credential_id": "255e01fc-65f6-43cd-8dfa-95e95fa95f6b",
     "bpn": "BPNL00000003CRHK"
   },
   {
     "credential_id": "255e01fc-65f6-43cd-8dfa-95e95fa95f6b",
     "bpn": "BPNL00000003CRHL"
+  },
+  {
+    "credential_id": "10df6ecd-faa3-45ed-8da5-96261f6542dd",
+    "bpn": "BPNL00000003CRHK"
   }
 ]

--- a/src/database/SsiAuthoritySchemaRegistry.Migrations/Seeder/Data/credentials.json
+++ b/src/database/SsiAuthoritySchemaRegistry.Migrations/Seeder/Data/credentials.json
@@ -10,48 +10,13 @@
     "name": "MembershipCredential"
   },
   {
-    "id": "255e01fc-65f6-43cd-8dfa-95e95fa95f62",
-    "type_id": 3,
-    "name": "TraceabilityCredential"
-  },
-  {
-    "id": "255e01fc-65f6-43cd-8dfa-95e95fa95f63",
-    "type_id": 3,
-    "name": "QualityCredential"
-  },
-  {
-    "id": "255e01fc-65f6-43cd-8dfa-95e95fa95f65",
-    "type_id": 3,
-    "name": "CircularEconomyCredential"
-  },
-  {
-    "id": "255e01fc-65f6-43cd-8dfa-95e95fa95f66",
-    "type_id": 3,
-    "name": "PcfCredential"
-  },
-  {
-    "id": "255e01fc-65f6-43cd-8dfa-95e95fa95f67",
-    "type_id": 3,
-    "name": "DemandCapacityCredential"
-  },
-  {
-    "id": "255e01fc-65f6-43cd-8dfa-95e95fa95f68",
-    "type_id": 3,
-    "name": "PurisCredential"
-  },
-  {
-    "id": "255e01fc-65f6-43cd-8dfa-95e95fa95f69",
-    "type_id": 3,
-    "name": "BusinessPartnerCredential"
-  },
-  {
-    "id": "255e01fc-65f6-43cd-8dfa-95e95fa95f6a",
-    "type_id": 3,
-    "name": "BehavioralTwinCredential"
-  },
-  {
     "id": "255e01fc-65f6-43cd-8dfa-95e95fa95f6b",
     "type_id": 4,
     "name": "DismantlerCredential"
+  },
+  {
+    "id": "10df6ecd-faa3-45ed-8da5-96261f6542dd",
+    "type_id": 3,
+    "name": "DataExchangeGovernanceCredential"
   }
 ]

--- a/tests/database/SsiAuthoritySchemaRegistry.DbAccess.Tests/CredentialRepositoryTests.cs
+++ b/tests/database/SsiAuthoritySchemaRegistry.DbAccess.Tests/CredentialRepositoryTests.cs
@@ -55,18 +55,11 @@ public class CredentialRepositoryTests
         var result = await sut.GetCredentials(null, null).ToListAsync();
 
         // Assert
-        result.Should().HaveCount(11).And.Satisfy(
+        result.Should().HaveCount(4).And.Satisfy(
             x => x.CredentialName == "BusinessPartnerNumber" && x.Credential == "BusinessPartnerCredential",
             x => x.CredentialName == "Membership" && x.Credential == "MembershipCredential",
-            x => x.CredentialName == "Framework" && x.Credential == "TraceabilityCredential",
-            x => x.CredentialName == "Framework" && x.Credential == "QualityCredential",
-            x => x.CredentialName == "Framework" && x.Credential == "CircularEconomyCredential",
-            x => x.CredentialName == "Framework" && x.Credential == "PcfCredential",
-            x => x.CredentialName == "Framework" && x.Credential == "DemandCapacityCredential",
-            x => x.CredentialName == "Framework" && x.Credential == "PurisCredential",
-            x => x.CredentialName == "Framework" && x.Credential == "BusinessPartnerCredential",
-            x => x.CredentialName == "Framework" && x.Credential == "BehavioralTwinCredential",
-            x => x.CredentialName == "CompanyRole" && x.Credential == "DismantlerCredential");
+            x => x.CredentialName == "CompanyRole" && x.Credential == "DismantlerCredential",
+            x => x.CredentialName == "Framework" && x.Credential == "DataExchangeGovernanceCredential");
     }
 
     [Fact]
@@ -93,15 +86,8 @@ public class CredentialRepositoryTests
         var result = await sut.GetCredentials(null, CredentialTypeId.Framework).ToListAsync();
 
         // Assert
-        result.Should().HaveCount(8).And.Satisfy(
-            x => x.CredentialName == "Framework" && x.Credential == "TraceabilityCredential",
-            x => x.CredentialName == "Framework" && x.Credential == "QualityCredential",
-            x => x.CredentialName == "Framework" && x.Credential == "CircularEconomyCredential",
-            x => x.CredentialName == "Framework" && x.Credential == "PcfCredential",
-            x => x.CredentialName == "Framework" && x.Credential == "DemandCapacityCredential",
-            x => x.CredentialName == "Framework" && x.Credential == "PurisCredential",
-            x => x.CredentialName == "Framework" && x.Credential == "BusinessPartnerCredential",
-            x => x.CredentialName == "Framework" && x.Credential == "BehavioralTwinCredential");
+        result.Should().ContainSingle().And.Satisfy(
+            x => x.CredentialName == "Framework" && x.Credential == "DataExchangeGovernanceCredential");
     }
 
     #endregion

--- a/tests/registry/SsiAuthoritySchemaRegistry.Service.Tests/Controllers/RegistryControllerTests.cs
+++ b/tests/registry/SsiAuthoritySchemaRegistry.Service.Tests/Controllers/RegistryControllerTests.cs
@@ -52,18 +52,11 @@ public class RegistryControllerTests(IntegrationTestFactory factory) : IClassFix
         var data = await _client.GetFromJsonAsync<IEnumerable<CredentialData>>($"{BaseUrl}/credentials", JsonOptions);
 
         // Assert
-        data.Should().NotBeNull().And.HaveCount(11).And.Satisfy(
-            x => x.CredentialName == "BusinessPartnerNumber" && x.Credential == "BusinessPartnerCredential",
-            x => x.CredentialName == "Membership" && x.Credential == "MembershipCredential",
-            x => x.CredentialName == "Framework" && x.Credential == "TraceabilityCredential",
-            x => x.CredentialName == "Framework" && x.Credential == "QualityCredential",
-            x => x.CredentialName == "Framework" && x.Credential == "CircularEconomyCredential",
-            x => x.CredentialName == "Framework" && x.Credential == "PcfCredential",
-            x => x.CredentialName == "Framework" && x.Credential == "DemandCapacityCredential",
-            x => x.CredentialName == "Framework" && x.Credential == "PurisCredential",
-            x => x.CredentialName == "Framework" && x.Credential == "BusinessPartnerCredential",
-            x => x.CredentialName == "Framework" && x.Credential == "BehavioralTwinCredential",
-            x => x.CredentialName == "CompanyRole" && x.Credential == "DismantlerCredential"
+        data.Should().NotBeNull().And.HaveCount(4).And.Satisfy(
+            x => x.CredentialName == "BusinessPartnerNumber" && x.Credential == "BusinessPartnerCredential" && x.Authorities.Count() == 1,
+            x => x.CredentialName == "Membership" && x.Credential == "MembershipCredential" && x.Authorities.Count() == 1,
+            x => x.CredentialName == "CompanyRole" && x.Credential == "DismantlerCredential" && x.Authorities.Count() == 2,
+            x => x.CredentialName == "Framework" && x.Credential == "DataExchangeGovernanceCredential" && x.Authorities.Count() == 1
         );
     }
 
@@ -85,15 +78,8 @@ public class RegistryControllerTests(IntegrationTestFactory factory) : IClassFix
         var data = await _client.GetFromJsonAsync<IEnumerable<CredentialData>>($"{BaseUrl}/credentials?credentialTypeId={CredentialTypeId.Framework}", JsonOptions);
 
         // Assert
-        data.Should().HaveCount(8).And.Satisfy(
-            x => x.CredentialName == "Framework" && x.Credential == "TraceabilityCredential",
-            x => x.CredentialName == "Framework" && x.Credential == "QualityCredential",
-            x => x.CredentialName == "Framework" && x.Credential == "CircularEconomyCredential",
-            x => x.CredentialName == "Framework" && x.Credential == "PcfCredential",
-            x => x.CredentialName == "Framework" && x.Credential == "DemandCapacityCredential",
-            x => x.CredentialName == "Framework" && x.Credential == "PurisCredential",
-            x => x.CredentialName == "Framework" && x.Credential == "BusinessPartnerCredential",
-            x => x.CredentialName == "Framework" && x.Credential == "BehavioralTwinCredential");
+        data.Should().HaveCount(1).And.Satisfy(
+            x => x.CredentialName == "Framework" && x.Credential == "DataExchangeGovernanceCredential");
     }
 
     #endregion


### PR DESCRIPTION
## Description

* remove unsupported framework credentials
* add DataExchangeGovernanceCredential Framework

## Why

To only have the supported frameworks in the registry

## Issue

Refs: #3

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-authority-schema-registry/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)