### PR TITLE
chore: remove example/test schema references

### DIFF
--- a/docs/requests/Org.Eclipse.TractusX.SsiAuthoritySchemaRegistry.Service.postman_collection.json
+++ b/docs/requests/Org.Eclipse.TractusX.SsiAuthoritySchemaRegistry.Service.postman_collection.json
@@ -128,7 +128,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"@context\": [\n        \"https://www.w3.org/2018/credentials/v1\",\n        \"https://w3id.org/security/suites/jws-2020/v1\",\n        \"https://raw.githubusercontent.com/catenax-ng/product-coreschemas/main/businessPartnerData\"\n    ],\n    \"id\": \"6b74cd89-6c25-4e3c-9fb7-3ee15c803afc\",\n    \"issuer\": \"test\",\n    \"type\": [\n        \"VerifiableCredential\",\n        \"MembershipCredential\"\n    ],\n    \"issuanceDate\": \"2024-05-29T01:01:01Z\",\n    \"expirationDate\": \"2024-12-31T23:59:59Z\",\n    \"credentialSubject\": {\n        \"id\": \"6b74cd89-6c25-4e3c-9fb7-3ee15c803afc\",\n        \"holderIdentifier\": \"Test\",\n        \"memberOf\": \"catena-x\"\n    }\n}",
+											"raw": "{\n    \"@context\": [\n        \"https://www.w3.org/2018/credentials/v1\",\n        \"https://w3id.org/security/suites/jws-2020/v1\"\n    ],\n    \"id\": \"6b74cd89-6c25-4e3c-9fb7-3ee15c803afc\",\n    \"issuer\": \"test\",\n    \"type\": [\n        \"VerifiableCredential\",\n        \"MembershipCredential\"\n    ],\n    \"issuanceDate\": \"2024-05-29T01:01:01Z\",\n    \"expirationDate\": \"2024-12-31T23:59:59Z\",\n    \"credentialSubject\": {\n        \"id\": \"6b74cd89-6c25-4e3c-9fb7-3ee15c803afc\",\n        \"holderIdentifier\": \"Test\",\n        \"memberOf\": \"catena-x\"\n    }\n}",
 											"options": {
 												"raw": {
 													"headerFamily": "json",

--- a/tests/registry/SsiAuthoritySchemaRegistry.Service.Tests/Controllers/SchemaControllerTests.cs
+++ b/tests/registry/SsiAuthoritySchemaRegistry.Service.Tests/Controllers/SchemaControllerTests.cs
@@ -49,8 +49,7 @@ public class SchemaControllerTests(IntegrationTestFactory factory) : IClassFixtu
                                       {
                                           "@context": [
                                               "https://www.w3.org/2018/credentials/v1",
-                                              "https://w3id.org/security/suites/jws-2020/v1",
-                                              "https://raw.githubusercontent.com/catenax-ng/product-coreschemas/main/businessPartnerData"
+                                              "https://w3id.org/security/suites/jws-2020/v1"
                                           ],
                                           "id": "6b74cd89-6c25-4e3c-9fb7-3ee15c803afc",
                                           "issuer": "test",
@@ -98,8 +97,7 @@ public class SchemaControllerTests(IntegrationTestFactory factory) : IClassFixtu
                                         {
                                             "@context": [
                                                 "https://www.w3.org/2018/credentials/v1",
-                                                "https://w3id.org/security/suites/jws-2020/v1",
-                                                "https://raw.githubusercontent.com/catenax-ng/product-coreschemas/main/businessPartnerData"
+                                                "https://w3id.org/security/suites/jws-2020/v1"
                                             ],
                                             "id": "6b74cd89-6c25-4e3c-9fb7-3ee15c803afc",
                                             "issuer": "test",
@@ -147,8 +145,7 @@ public class SchemaControllerTests(IntegrationTestFactory factory) : IClassFixtu
                                       {
                                           "@context": [
                                               "https://www.w3.org/2018/credentials/v1",
-                                              "https://w3id.org/security/suites/jws-2020/v1",
-                                              "https://raw.githubusercontent.com/catenax-ng/product-coreschemas/main/businessPartnerData"
+                                              "https://w3id.org/security/suites/jws-2020/v1"
                                           ],
                                           "id": "6b74cd89-6c25-4e3c-9fb7-3ee15c803afc",
                                           "issuer": "test",
@@ -199,8 +196,7 @@ public class SchemaControllerTests(IntegrationTestFactory factory) : IClassFixtu
                                       {
                                           "@context": [
                                               "https://www.w3.org/2018/credentials/v1",
-                                              "https://w3id.org/security/suites/jws-2020/v1",
-                                              "https://raw.githubusercontent.com/catenax-ng/product-coreschemas/main/businessPartnerData"
+                                              "https://w3id.org/security/suites/jws-2020/v1"
                                           ],
                                           "id": "6b74cd89-6c25-4e3c-9fb7-3ee15c803afc",
                                           "issuer": "test",


### PR DESCRIPTION
## Description

remove schema references to catenax-ng/product-coreschemas
references were used in tests and example request only

## Why

https://github.com/eclipse-tractusx/ssi-authority-schema-registry/issues/55

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-authority-schema-registry/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [x] I have performed a self-review of my own changes