### PR TITLE
feat(validation): adjust schema validation

### DIFF
--- a/docs/api/asr-service.yaml
+++ b/docs/api/asr-service.yaml
@@ -48,7 +48,6 @@ paths:
       parameters:
         - name: schemaType
           in: query
-          required: true
           schema:
             $ref: '#/components/schemas/CredentialSchemaType'
       requestBody:

--- a/src/registry/SsiAuthoritySchemaRegistry.Service/BusinessLogic/ISchemaBusinessLogic.cs
+++ b/src/registry/SsiAuthoritySchemaRegistry.Service/BusinessLogic/ISchemaBusinessLogic.cs
@@ -25,5 +25,5 @@ namespace Org.Eclipse.TractusX.SsiAuthoritySchemaRegistry.Service.BusinessLogic;
 
 public interface ISchemaBusinessLogic : ITransient
 {
-    Task<bool> Validate(CredentialSchemaType schemaType, JsonDocument content, CancellationToken cancellationToken);
+    Task<bool> Validate(CredentialSchemaType? schemaType, JsonDocument content);
 }

--- a/src/registry/SsiAuthoritySchemaRegistry.Service/Controllers/SchemaController.cs
+++ b/src/registry/SsiAuthoritySchemaRegistry.Service/Controllers/SchemaController.cs
@@ -12,10 +12,10 @@ public static class SchemaController
     {
         var schema = group.MapGroup("/schema");
 
-        schema.MapPost("validate", ([FromQuery] CredentialSchemaType schemaType, [FromBody] JsonDocument content, CancellationToken cancellationToken, ISchemaBusinessLogic logic) => logic.Validate(schemaType, content, cancellationToken))
+        schema.MapPost("validate", ([FromBody] JsonDocument content, [FromServices] ISchemaBusinessLogic logic, [FromQuery] CredentialSchemaType? schemaType = null) => logic.Validate(schemaType, content))
             .WithSwaggerDescription("Gets all credentials with optional filter possibilities",
                 "Example: POST: api/schema/validate",
-                "The type of the schema that should be validated",
+                "Optional: The type of the schema that should be validated",
                 "The schema as json")
             .WithDefaultResponses()
             .Produces(StatusCodes.Status200OK, typeof(bool), Constants.JsonContentType);


### PR DESCRIPTION
## Description

schemaType is made optional

## Why

To give a better flexibility for the user to execute the schema validation

## Issue

Refs: #34

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-authority-schema-registry/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)