### PR TITLE
docs: adjust archtiecture index

### DIFF
--- a/docs/architecture/Index.md
+++ b/docs/architecture/Index.md
@@ -4,17 +4,12 @@ This documentation follows the arc42 template to provide a comprehensive overvie
 
 ## Table of Content
 
-- [01. Introduction and Goals (To be added.)](./Index.md)
 - [02. Architecture Constraints](./02_architecture_constraints.md)
 - [03. Context and Scope](./03_system_scope_and_context.md)
 - [04. Solution Strategy](./04_solution_strategy.md)
 - [05. Building Block View](./05_building_block_view.md)
-- [06. Runtime View (To be added.)](./Index.md)
-- [07. Deployment View (To be added.)](./Index.md)
 - [08. Concepts](./08_concepts.md)
-- [09. Architecture Decisions (To be added)](./Index.md)
 - [10. Quality Requirements](./10_quality_requirements.md)
-- [11. Technical Risks (To be added)](./Index.md)
 - [12. Glossary](12_glossary.md)
 
 ## NOTICE


### PR DESCRIPTION
## Description

Removed all to be added links from the index of the architecture documentation

## Why

To only have working links in the documentation

## Issue

N/A

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-authority-schema-registry/blob/main/docs/admin/dev-process/How%20to%20contribute.md)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)