### PR TITLE
build(1.1.0-rc.1): merge release into main

### DIFF
--- a/.tractusx
+++ b/.tractusx
@@ -20,4 +20,4 @@
 product: "SSI Authority & Schema Registry"
 leadingRepository: "https://github.com/eclipse-tractusx/ssi-authority-schema-registry"
 openApiSpecs:
-- "https://raw.githubusercontent.com/eclipse-tractusx/ssi-authority-schema-registry/refs/tags/ssi-asr-1.1.0-alpha.1/docs/api/asr-service.yaml"
+- "https://raw.githubusercontent.com/eclipse-tractusx/ssi-authority-schema-registry/refs/tags/ssi-asr-1.1.0-rc.1/docs/api/asr-service.yaml"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.1.0-rc.1](https://github.com/eclipse-tractusx/ssi-authority-schema-registry/compare/v1.1.0-alpha.1...v1.1.0-rc.1) (2024-11-11)
+
+### Features
+
+* **seeding:** make authorities bpn configurable via helm chart ([020d4b7](https://github.com/eclipse-tractusx/ssi-authority-schema-registry/commit/020d4b742c15b119ecfe3f146d91840687ba45f7)), closes [#77](https://github.com/eclipse-tractusx/ssi-authority-schema-registry/issues/77)
+
 ## [1.1.0-alpha.1](https://github.com/eclipse-tractusx/ssi-authority-schema-registry/compare/v1.0.0-rc.1...v1.1.0-alpha.1) (2024-10-24)
 
 

--- a/charts/ssi-asr/Chart.yaml
+++ b/charts/ssi-asr/Chart.yaml
@@ -20,8 +20,8 @@
 apiVersion: v2
 name: ssi-asr
 type: application
-version: 1.1.0-alpha.1
-appVersion: 1.1.0-alpha.1
+version: 1.1.0-rc.1
+appVersion: 1.1.0-rc.1
 description: Helm chart for SSI Authority & Schema Registry
 home: https://github.com/eclipse-tractusx/ssi-authority-schema-registry
 dependencies:

--- a/charts/ssi-asr/README.md
+++ b/charts/ssi-asr/README.md
@@ -27,7 +27,7 @@ To use the helm chart as a dependency:
 dependencies:
   - name: ssi-asr
     repository: https://eclipse-tractusx.github.io/charts/dev
-    version: 1.1.0-alpha.1
+    version: 1.1.0-rc.1
 ```
 
 ## Requirements
@@ -40,6 +40,9 @@ dependencies:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| authorities | object | `{"authorityOne":{"bpn":"BPNL00000003CRHK"},"authorityTwo":{"bpn":"BPNL00000003CRHL"}}` | Set information related the authorities |
+| authorities.authorityOne | object | `{"bpn":"BPNL00000003CRHK"}` | The first authority |
+| authorities.authorityTwo | object | `{"bpn":"BPNL00000003CRHL"}` | The second authority |
 | service.image.name | string | `"docker.io/tractusx/ssi-authority-schema-registry-service"` |  |
 | service.image.tag | string | `""` |  |
 | service.image.pullSecrets | list | `[]` |  |
@@ -59,8 +62,7 @@ dependencies:
 | migrations.image.pullSecrets | list | `[]` |  |
 | migrations.imagePullPolicy | string | `"IfNotPresent"` |  |
 | migrations.resources | object | `{"limits":{"cpu":"75m","memory":"200M"},"requests":{"cpu":"25m","memory":"200M"}}` | We recommend to review the default resource limits as this should a conscious choice. |
-| migrations.seeding.testDataEnvironments | string | `""` |  |
-| migrations.seeding.testDataPaths | string | `"Seeder/Data"` |  |
+| migrations.seeding.useInitial | bool | `true` | Enables dynamic seeding of information related to the operator company: operator.bpn; If set to `true` the data configured in the config map 'configmap-seeding-initialdata.yaml' will be taken to insert the initial data; |
 | migrations.logging.default | string | `"Information"` |  |
 | dotnetEnvironment | string | `"Production"` |  |
 | dbConnection.schema | string | `"asr"` |  |

--- a/docs/api/asr-service.yaml
+++ b/docs/api/asr-service.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.1
 info:
   title: Org.Eclipse.TractusX.SsiAuthoritySchemaRegistry.Service
-  version: v1.1.0-alpha.1
+  version: v1.1.0-rc.1
 paths:
   /api/registry/credentials:
     get:

--- a/environments/argocd-app-templates/appsetup-int.yaml
+++ b/environments/argocd-app-templates/appsetup-int.yaml
@@ -28,7 +28,7 @@ spec:
   source:
     path: charts/ssi-asr
     repoURL: 'https://github.com/eclipse-tractusx/ssi-authority-schema-registry.git'
-    targetRevision: ssi-asr-1.1.0-alpha.1
+    targetRevision: ssi-asr-1.1.0-rc.1
     plugin:
       env:
         - name: AVP_SECRET

--- a/environments/argocd-app-templates/appsetup-stable.yaml
+++ b/environments/argocd-app-templates/appsetup-stable.yaml
@@ -28,7 +28,7 @@ spec:
   source:
     path: charts/ssi-asr
     repoURL: 'https://github.com/eclipse-tractusx/ssi-authority-schema-registry.git'
-    targetRevision: ssi-asr-1.1.0-alpha.1
+    targetRevision: ssi-asr-1.1.0-rc.1
     plugin:
       env:
         - name: AVP_SECRET

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -20,6 +20,6 @@
 <Project>
   <PropertyGroup>
     <VersionPrefix>1.1.0</VersionPrefix>
-    <VersionSuffix>alpha.1</VersionSuffix>
+    <VersionSuffix>rc.1</VersionSuffix>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Description

Merge latest release into main

## Why

To have the latest release changes available in main

## Issue

https://github.com/eclipse-tractusx/portal/issues/465

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-authority-schema-registry/blob/main/docs/admin/dev-process/How%20to%20contribute.md)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)