### PR TITLE
fix(seeding): adjust order of deletion

### DIFF
--- a/src/database/SsiAuthoritySchemaRegistry.Migrations/Seeder/BatchDeleteSeeder.cs
+++ b/src/database/SsiAuthoritySchemaRegistry.Migrations/Seeder/BatchDeleteSeeder.cs
@@ -46,9 +46,9 @@ public class BatchDeleteSeeder(RegistryContext context, ILogger<BatchDeleteSeede
             return;
         }
 
-        await SeedTable<Authority>("authorities", x => x.Bpn, cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
-        await SeedTable<Credential>("credentials", x => x.Id, cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
         await SeedTable<CredentialAuthority>("credential_authorities", x => new { x.CredentialId, x.Bpn }, cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
+        await SeedTable<Credential>("credentials", x => x.Id, cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
+        await SeedTable<Authority>("authorities", x => x.Bpn, cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
 
         await context.SaveChangesAsync(cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
     }


### PR DESCRIPTION
## Description

Adjust the order of deletion

## Why

Due to the wrong order the migration job fails when deleting entries that are not existing anymore

## Issue

Refs: #93

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-authority-schema-registry/blob/main/docs/admin/dev-process/How%20to%20contribute.md)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)