### PR TITLE
build(1.1.0-rc.2): merge release into main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.1.0-rc.2](https://github.com/eclipse-tractusx/ssi-authority-schema-registry/compare/v1.1.0-rc.1...v1.1.0-rc.2) (2024-11-13)
+
+### Bug Fixes
+
+* **seeding:** adjust order of deletion ([562afcd](https://github.com/eclipse-tractusx/ssi-authority-schema-registry/commit/562afcd8b870ae1e4273508b597e0faf9389b43a)), closes [#93](https://github.com/eclipse-tractusx/ssi-authority-schema-registry/issues/93)
+
 ## [1.1.0-rc.1](https://github.com/eclipse-tractusx/ssi-authority-schema-registry/compare/v1.1.0-alpha.1...v1.1.0-rc.1) (2024-11-11)
 
 ### Features


### PR DESCRIPTION
## Description

Merge latest release into main

## Why

To have the latest release changes available in main

## Issue

https://github.com/eclipse-tractusx/portal/issues/465

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-authority-schema-registry/blob/main/docs/admin/dev-process/How%20to%20contribute.md)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)