### PR TITLE
docs: add api hub to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ For **information about the SSI Authority & Schema Registry**, please refer to t
 
 For **installation** details, please refer to the [README.md](./charts/ssi-asr/README.md) of the provided helm chart.
 
+To see the latest open API specs you can have a look at the [API Hub](https://eclipse-tractusx.github.io/api-hub/ssi-authority-schema-registry/).
+
 ## How to build and run
 
 Install the [.NET 8.0 SDK](https://www.microsoft.com/net/download).

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,12 +4,12 @@ This repository provides the backend code for the SSI Authority & Schema Registr
 
 The following table links you to the respective documentations.
 
-| Documentation                                                    | Purpose                                                                                 |
-|------------------------------------------------------------------|-----------------------------------------------------------------------------------------|
-| [Arc42](architecture/Index.md)                                   | Architecture Documentation for the SSI Authority & Schema Registry (SSI ASR).           |
-| [How to contribute](./admin/dev-process/How%20to%20contribute.md)| Information relevant, if you contribute in ssi authority schema registry development.   |
-| [Administration Guide](admin/Admin_Guide.md)                     | Information relevant, if you want to use the ssi authority schema registry application. |
-| [API Documentation](api/API_Doc.md)                              | Information about the endpoints.                                                        |
+| Documentation                                                                                                              | Purpose                                                                                 |
+| -------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| [Arc42](architecture/Index.md)                                                                                             | Architecture Documentation for the SSI Authority & Schema Registry (SSI ASR).           |
+| [How to contribute](./admin/dev-process/How%20to%20contribute.md)                                                          | Information relevant, if you contribute in ssi authority schema registry development.   |
+| [Administration Guide](admin/Admin_Guide.md)                                                                               | Information relevant, if you want to use the ssi authority schema registry application. |
+| [API Documentation](api/API_Doc.md) & [API Hub](https://eclipse-tractusx.github.io/api-hub/ssi-authority-schema-registry/) | Information about the endpoints.                                                        |
 
 ## NOTICE
 

--- a/docs/admin/release-process/Release Process.md
+++ b/docs/admin/release-process/Release Process.md
@@ -55,7 +55,7 @@ _build: update readme for vx.x.x_
 
 ### 4. Update .tractusx
 
-Adjust links of the open api specifications in the .tractusx file.
+To get the latest version of the api specs build the solution once. After that adjust the links of the open api specifications in the .tractusx file.
 
 All stable releases should be listed. In case of a pre-release version (rc, alpha, etc.), only the latest one should be listed.
 

--- a/docs/api/API_Doc.md
+++ b/docs/api/API_Doc.md
@@ -6,6 +6,10 @@ This document provides information on the endpoints.
 
 There is an [OpenAPI 3.0.1 specification document](./asr-service.yaml) available.
 
+## API Hub
+
+To see the latest open API specs you can have a look at the [API Hub](https://eclipse-tractusx.github.io/api-hub/ssi-authority-schema-registry/).
+
 ## Postman
 
 There is a [postman collection](./postman) containing information on how to provide master data and some basic data to test the application.


### PR DESCRIPTION
## Description

Add API Hub links to the documentation

## Why

To have the api hub linked in the docs

## Issue

N/A

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-authority-schema-registry/blob/main/docs/admin/dev-process/How%20to%20contribute.md)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)