### PR TITLE
fix(migrations): add custom history repository

### DIFF
--- a/src/database/SsiAuthoritySchemaRegistry.DbAccess/SsiAuthoritySchemaRegistry.DbAccess.csproj
+++ b/src/database/SsiAuthoritySchemaRegistry.DbAccess/SsiAuthoritySchemaRegistry.DbAccess.csproj
@@ -35,8 +35,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="9.0.1" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.3" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DependencyInjection" Version="3.0.0" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling" Version="3.0.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DependencyInjection" Version="3.3.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling" Version="3.3.0" />
   </ItemGroup>
 
 </Project>

--- a/src/database/SsiAuthoritySchemaRegistry.Migrations/Program.cs
+++ b/src/database/SsiAuthoritySchemaRegistry.Migrations/Program.cs
@@ -18,9 +18,11 @@
  ********************************************************************************/
 
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.DBAccess;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Logging;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Seeding.DependencyInjection;
 using Org.Eclipse.TractusX.SsiAuthoritySchemaRegistry.Entities;
@@ -38,7 +40,8 @@ try
                 .AddDbContext<RegistryContext>(o =>
                     o.UseNpgsql(hostContext.Configuration.GetConnectionString("RegistryDb"),
                         x => x.MigrationsAssembly(Assembly.GetExecutingAssembly().GetName().Name)
-                            .MigrationsHistoryTable("__efmigrations_history_authority_schema_registry", "public")))
+                            .MigrationsHistoryTable("__efmigrations_history_authority_schema_registry", "public"))
+                        .ReplaceService<IHistoryRepository, CustomNpgsqlHistoryRepository>())
                 .AddDatabaseInitializer<RegistryContext>(hostContext.Configuration.GetSection("Seeding"));
         })
         .AddLogging()

--- a/src/database/SsiAuthoritySchemaRegistry.Migrations/SsiAuthoritySchemaRegistry.Migrations.csproj
+++ b/src/database/SsiAuthoritySchemaRegistry.Migrations/SsiAuthoritySchemaRegistry.Migrations.csproj
@@ -48,9 +48,10 @@
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
         <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.1" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.3" />
-        <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Linq" Version="3.0.0" />
-        <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Logging" Version="3.0.0" />
-        <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Seeding" Version="3.0.0" />
+        <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DBAccess" Version="3.3.0" />
+        <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Linq" Version="3.3.0" />
+        <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Logging" Version="3.3.0" />
+        <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Seeding" Version="3.3.0" />
         <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.0" />
     </ItemGroup>
 

--- a/src/registry/SsiAuthoritySchemaRegistry.Service/SsiAuthoritySchemaRegistry.Service.csproj
+++ b/src/registry/SsiAuthoritySchemaRegistry.Service/SsiAuthoritySchemaRegistry.Service.csproj
@@ -42,7 +42,7 @@
     <PackageReference Include="JsonSchema.Net" Version="7.3.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.1" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Web" Version="3.0.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Web" Version="3.3.0" />
     <PackageReference Include="System.Json" Version="4.8.0" />
     <PackageReference Include="System.Linq" Version="4.3.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />

--- a/tests/database/SsiAuthoritySchemaRegistry.DbAccess.Tests/SsiAuthoritySchemaRegistry.DbAccess.Tests.csproj
+++ b/tests/database/SsiAuthoritySchemaRegistry.DbAccess.Tests/SsiAuthoritySchemaRegistry.DbAccess.Tests.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="FakeItEasy" Version="8.3.0" />
     <PackageReference Include="FluentAssertions" Version="6.12.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DateTimeProvider" Version="3.0.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DateTimeProvider" Version="3.3.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="4.1.0" />
     <PackageReference Include="xunit" Version="2.9.3" />


### PR DESCRIPTION
## Description

Add custom history repository to create the migration history table in public schema

## Why

With the upgrade to dotnet 9 the migration only can be executed with the schema user having create permission in the public schema

## Issue

N/A

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-authority-schema-registry/blob/main/docs/admin/dev-process/How%20to%20contribute.md)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)