### PR TITLE
fix(errorHandling): adjust general error handler

### DIFF
--- a/src/database/SsiAuthoritySchemaRegistry.DbAccess/SsiAuthoritySchemaRegistry.DbAccess.csproj
+++ b/src/database/SsiAuthoritySchemaRegistry.DbAccess/SsiAuthoritySchemaRegistry.DbAccess.csproj
@@ -35,8 +35,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="9.0.1" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.3" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DependencyInjection" Version="3.3.0" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling" Version="3.3.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DependencyInjection" Version="3.7.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling" Version="3.7.0" />
   </ItemGroup>
 
 </Project>

--- a/src/database/SsiAuthoritySchemaRegistry.Migrations/SsiAuthoritySchemaRegistry.Migrations.csproj
+++ b/src/database/SsiAuthoritySchemaRegistry.Migrations/SsiAuthoritySchemaRegistry.Migrations.csproj
@@ -48,10 +48,10 @@
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
         <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.1" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.3" />
-        <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DBAccess" Version="3.3.0" />
-        <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Linq" Version="3.3.0" />
-        <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Logging" Version="3.3.0" />
-        <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Seeding" Version="3.3.0" />
+        <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DBAccess" Version="3.7.0" />
+        <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Linq" Version="3.7.0" />
+        <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Logging" Version="3.7.0" />
+        <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Seeding" Version="3.7.0" />
         <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.0" />
     </ItemGroup>
 

--- a/src/registry/SsiAuthoritySchemaRegistry.Service/BusinessLogic/SchemaBusinessLogic.cs
+++ b/src/registry/SsiAuthoritySchemaRegistry.Service/BusinessLogic/SchemaBusinessLogic.cs
@@ -19,6 +19,7 @@
 
 using Json.Schema;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling;
+using Org.Eclipse.TractusX.SsiAuthoritySchemaRegistry.Service.ErrorHandling;
 using Org.Eclipse.TractusX.SsiAuthoritySchemaRegistry.Service.Models;
 using System.Reflection;
 using System.Text.Json;
@@ -32,7 +33,7 @@ public class SchemaBusinessLogic : ISchemaBusinessLogic
         var location = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
         if (location == null)
         {
-            throw new UnexpectedConditionException("Assembly location must be set");
+            throw UnexpectedConditionException.Create(ErrorTypes.ASSEMBLY_LOCATION_NOT_SET);
         }
 
         if (schemaType is not null)

--- a/src/registry/SsiAuthoritySchemaRegistry.Service/ErrorHandling/ErrorMessageContainer.cs
+++ b/src/registry/SsiAuthoritySchemaRegistry.Service/ErrorHandling/ErrorMessageContainer.cs
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -17,9 +17,22 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-namespace Org.Eclipse.TractusX.SsiAuthoritySchemaRegistry.DbAccess;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Service;
+using System.Collections.Immutable;
 
-public interface IRegistryRepositories
+namespace Org.Eclipse.TractusX.SsiAuthoritySchemaRegistry.Service.ErrorHandling;
+
+public class ErrorMessageContainer : IErrorMessageContainer
 {
-    T GetInstance<T>();
+    private static readonly IReadOnlyDictionary<int, string> Messages = ImmutableDictionary.CreateRange<int, string>([
+        new((int)ErrorTypes.ASSEMBLY_LOCATION_NOT_SET, "Assembly location must be set")
+    ]);
+
+    public Type Type { get => typeof(ErrorTypes); }
+    public IReadOnlyDictionary<int, string> MessageContainer { get => Messages; }
+}
+
+public enum ErrorTypes
+{
+    ASSEMBLY_LOCATION_NOT_SET
 }

--- a/src/registry/SsiAuthoritySchemaRegistry.Service/Program.cs
+++ b/src/registry/SsiAuthoritySchemaRegistry.Service/Program.cs
@@ -17,10 +17,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Service;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Web;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Models.Extensions;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Web;
 using Org.Eclipse.TractusX.SsiAuthoritySchemaRegistry.DbAccess.DependencyInjection;
 using Org.Eclipse.TractusX.SsiAuthoritySchemaRegistry.Service.Controllers;
+using Org.Eclipse.TractusX.SsiAuthoritySchemaRegistry.Service.ErrorHandling;
 using System.Text.Json.Serialization;
 
 var version = AssemblyExtension.GetApplicationVersion();
@@ -29,6 +32,9 @@ await WebApplicationBuildRunner
     .BuildAndRunWebApplicationAsync<Program>(args, "registry", version, ".Registry",
         builder =>
         {
+            builder.Services.AddSingleton<IErrorMessageContainer, ErrorMessageContainer>();
+            builder.Services.AddSingleton<IErrorMessageService, ErrorMessageService>();
+            builder.Services.AddTransient<GeneralHttpExceptionMiddleware>();
             builder.Services.AddEndpointsApiExplorer();
             builder.Services.AddRegistryRepositories(builder.Configuration);
             builder.Services.ConfigureHttpJsonOptions(options =>
@@ -42,6 +48,7 @@ await WebApplicationBuildRunner
         },
         (app, _) =>
         {
+            app.UseMiddleware<GeneralHttpExceptionMiddleware>();
             app.MapGroup("/api")
                 .WithOpenApi()
                 .MapRegistryApi()

--- a/src/registry/SsiAuthoritySchemaRegistry.Service/SsiAuthoritySchemaRegistry.Service.csproj
+++ b/src/registry/SsiAuthoritySchemaRegistry.Service/SsiAuthoritySchemaRegistry.Service.csproj
@@ -42,7 +42,7 @@
     <PackageReference Include="JsonSchema.Net" Version="7.3.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.1" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Web" Version="3.3.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Web" Version="3.7.0" />
     <PackageReference Include="System.Json" Version="4.8.0" />
     <PackageReference Include="System.Linq" Version="4.3.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />

--- a/tests/database/SsiAuthoritySchemaRegistry.DbAccess.Tests/SsiAuthoritySchemaRegistry.DbAccess.Tests.csproj
+++ b/tests/database/SsiAuthoritySchemaRegistry.DbAccess.Tests/SsiAuthoritySchemaRegistry.DbAccess.Tests.csproj
@@ -33,7 +33,6 @@
     <PackageReference Include="FakeItEasy" Version="8.3.0" />
     <PackageReference Include="FluentAssertions" Version="6.12.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DateTimeProvider" Version="3.3.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="4.1.0" />
     <PackageReference Include="xunit" Version="2.9.3" />


### PR DESCRIPTION
## Description

fixing the current error handling

## Why

after the net 9 upgrade the general error handling was broken and always returned a 500

## Issue

N/A

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-authority-schema-registry/blob/main/docs/admin/dev-process/How%20to%20contribute.md)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)