### PR TITLE
chore: fix and improve dependencies check

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -77,6 +77,14 @@ jobs:
       - name: Generate Dependencies file
         run: java -jar ./org.eclipse.dash.licenses.jar PACKAGES -project automotive.tractusx -summary DEPENDENCIES || true
 
+      - name: Check for restricted dependencies
+        run: |
+          restricted=$(grep ' restricted,' DEPENDENCIES || true)
+          if [[ -n "$restricted" ]]; then
+            echo "The following dependencies are restricted: $restricted"
+            exit 1
+          fi
+
       - name: Check if dependencies were changed
         id: dependencies-changed
         run: |
@@ -88,15 +96,6 @@ jobs:
             echo "dependencies not changed"
             echo "changed=false" >> $GITHUB_OUTPUT
           fi
-
-      - name: Check for restricted dependencies
-        run: |
-          restricted=$(grep ' restricted,' DEPENDENCIES || true)
-          if [[ -n "$restricted" ]]; then
-            echo "The following dependencies are restricted: $restricted"
-            exit 1
-          fi
-        if: steps.dependencies-changed.outputs.changed == 'true'
 
       - name: Upload DEPENDENCIES file
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -22,8 +22,22 @@ name: Check Dependencies
 on:
   push:
     branches: [main]
+    paths:
+      # all csproj files which include the external packages
+      - '**.csproj'
+      # dependencies file
+      - 'DEPENDENCIES'
+      # workflow file
+      - '.github/workflows/dependencies.yaml'
   pull_request:
     types: [opened, synchronize, reopened]
+    paths:
+      # all csproj files which include the external packages
+      - '**.csproj'
+      # dependencies file
+      - 'DEPENDENCIES'
+      # workflow file
+      - '.github/workflows/dependencies.yaml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -32,7 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet-version: ['9.0']
+        # dotnet list command doesn't work with 9.0.202, switch to 9.0.104 as a workaround
+        dotnet-version: ['9.0.104']
 
     steps:
   


### PR DESCRIPTION
## Description

- fix dotnet list command: does work with dotnet 9.0.104 but not with 9.0.202 (currently latest), we switch this pipeline to 9.0.104 as a workaround
- restrict workflow to relevant paths
- check always for the restricted dependencies regardless if file was changed

## Issue

#148 

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-authority-schema-registry/blob/main/docs/admin/dev-process/How%20to%20contribute.md)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes