### PR TITLE
build(2.0.1-rc.2): change bitnami image repository

### DIFF
--- a/charts/ssi-asr/Chart.yaml
+++ b/charts/ssi-asr/Chart.yaml
@@ -20,8 +20,8 @@
 apiVersion: v2
 name: ssi-asr
 type: application
-version: 2.0.1-rc.1
-appVersion: 2.0.1-rc.1
+version: 2.0.1-rc.2
+appVersion: 2.0.1-rc.2
 description: Helm chart for SSI Authority & Schema Registry
 home: https://github.com/eclipse-tractusx/ssi-authority-schema-registry
 dependencies:

--- a/charts/ssi-asr/README.md
+++ b/charts/ssi-asr/README.md
@@ -27,7 +27,7 @@ To use the helm chart as a dependency:
 dependencies:
   - name: ssi-asr
     repository: https://eclipse-tractusx.github.io/charts/dev
-    version: 2.0.1-rc.1
+    version: 2.0.1-rc.2
 ```
 
 ## Requirements
@@ -68,7 +68,7 @@ dependencies:
 | dbConnection.schema | string | `"asr"` |  |
 | dbConnection.sslMode | string | `"Disable"` |  |
 | postgresql.enabled | bool | `true` | PostgreSQL chart configuration; default configurations: host: "asr-postgresql-primary", port: 5432; Switch to enable or disable the PostgreSQL helm chart. |
-| postgresql.image | object | `{"tag":"15-debian-12"}` | Setting image tag to major to get latest minor updates |
+| postgresql.image | object | `{"registry":"docker.io","repository":"bitnamilegacy/postgresql","tag":"15-debian-12"}` | Setting image tag to major to get latest minor updates |
 | postgresql.commonLabels."app.kubernetes.io/version" | string | `"15"` |  |
 | postgresql.auth.username | string | `"asr"` | Non-root username. |
 | postgresql.auth.database | string | `"asr"` | Database name. |

--- a/charts/ssi-asr/values.yaml
+++ b/charts/ssi-asr/values.yaml
@@ -92,6 +92,8 @@ postgresql:
   enabled: true
   # -- Setting image tag to major to get latest minor updates
   image:
+    registry: docker.io
+    repository: bitnamilegacy/postgresql
     tag: "15-debian-12"
   commonLabels:
     app.kubernetes.io/version: "15"


### PR DESCRIPTION
## Description

- change bitnami image path to legacy repository

## Why

- Bitnami now requires a paid subscription to use their images.

## Issue

Closes: #197

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
